### PR TITLE
Change config and store to work so that multiple project use the same data directory.

### DIFF
--- a/www/simply-edit/config.php
+++ b/www/simply-edit/config.php
@@ -8,8 +8,11 @@
 	require_once('http.php');
 	require_once('filesystem.php');
 	require_once('htpasswd.php');
+	require_once('determine_basedir.php');
 
-	filesystem::basedir(dirname(__DIR__)); // parent of current directory
+	$basedir = determine_basedir();
+
+	filesystem::basedir($basedir);
 
 	filesystem::allow('/data/','application/json.*');
 	filesystem::allow('/data/','text/.*');

--- a/www/simply-edit/determine_basedir.php
+++ b/www/simply-edit/determine_basedir.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * determine where data should be stored so it is accessible from the web.
+ *
+ * Under normal circumstances, using __DIR__ for $basedir would suffice. However,
+ * for symlinks this would cause problems. Hence we need to find the path where
+ * the $basedir is supposed to be, regardless of symlinks.
+ *
+ * There are three ways to do so, but not all are guaranteed to be available
+ * (depending on server environment and configuration).
+ *
+ * @return string
+ *
+ * @throws RuntimeException
+ */
+function determine_basedir()
+{
+    if (isset($_SERVER['SCRIPT_FILENAME'])) {
+        $currentFile = $_SERVER['SCRIPT_FILENAME'];
+    } elseif (isset($_SERVER['DOCUMENT_ROOT'], $_SERVER['SCRIPT_NAME'])) {
+        $currentFile = $_SERVER['DOCUMENT_ROOT'] . $_SERVER['SCRIPT_NAME'];
+    } elseif (isset($_SERVER['DOCUMENT_ROOT'], $_SERVER['PHP_SELF'])) {
+        $currentFile = $_SERVER['DOCUMENT_ROOT'] . $_SERVER['PHP_SELF'];
+    } else {
+        throw new \RuntimeException('Could not reliably determine base directory to store data. ($_SERVER variables "DOCUMENT_ROOT", "PHP_SELF", "SCRIPT_FILENAME", and "SCRIPT_NAME" are all unavailable)');
+    }
+
+    return dirname($currentFile, 2);
+}

--- a/www/simply-edit/filesystem.php
+++ b/www/simply-edit/filesystem.php
@@ -52,11 +52,18 @@ class filesystem {
 
 	private static function realpaths($dirname, $filename)
 	{
-		$realfile = realpath(self::append(self::$basedir, $dirname) . $filename );
-		$realdir  = realpath(self::append(self::$basedir, $dirname));
+		$basedir = self::$basedir;
+
+		if ($basedir !== realpath($basedir)) {
+			// Symlink used
+			$basedir = realpath($basedir);
+		}
+
+		$realfile = realpath(self::append($basedir, $dirname) . $filename );
+		$realdir  = realpath(self::append($basedir, $dirname));
 
 		if ( !$realdir ) {
-			$realdir = self::append(self::$basedir, $dirname);
+			$realdir = self::append($basedir, $dirname);
 		} else {
 			$realdir .= '/';
 		}
@@ -65,8 +72,8 @@ class filesystem {
 			$realfile = $realdir . $filename;
 		}
 
-		if ( strpos($realfile, self::$basedir)!==0
-			|| strpos($realdir, self::$basedir)!==0 ) {
+		if ( strpos($realfile, $basedir) !== 0
+			|| strpos($realdir, $basedir) !== 0 ) {
 			throw new fsException('Attempted file access outside base directory', 110);
 		}
 		return [ $realdir, $realfile ];


### PR DESCRIPTION
In the current implementation, if a projects includes the simply-backend multiple times (as happens with simply-design) then each inclusion uses their own `data` directory. 

If such a data directory is (inside) a symlinked diectory, things break. This is caused by the way the `basepath` is determined and subsequently valided in the `realpaths` method.

This MR makes it possible for the multiple project setup to work with symlinks.