### PR TITLE
Add check handling settings.json not existing.

### DIFF
--- a/www/simply-edit/config.php
+++ b/www/simply-edit/config.php
@@ -1,4 +1,7 @@
 <?php
+	// Make sure that any preliminary output does not cause incorrect 200 return codes
+	ob_start();
+
 	error_reporting(E_ERROR & E_WARNING);
 	ini_set('display_errors',1);
 
@@ -11,7 +14,6 @@
 	filesystem::allow('/data/','application/json.*');
 	filesystem::allow('/data/','text/.*');
 	filesystem::allow('/img/','image/.*');
-	
 	filesystem::allow('/files/','.*');
 
 	filesystem::check('put', '/data/data.json', function($filename, $realfile) {
@@ -35,4 +37,11 @@
 		}
 	});
 
-	$settings = json_decode(filesystem::get('/data/','settings.json'));
+	try {
+		$str = filesystem::get('/data/', 'settings.json');
+	} catch (Exception $e) {
+		http::response( 500, [ 'error' => $e->getCode(), 'message' => $e->getMessage() ] );
+		die;
+	}
+
+	$settings = json_decode($str);

--- a/www/simply-edit/http.php
+++ b/www/simply-edit/http.php
@@ -120,6 +120,7 @@ class http {
 			break;
 			case 'json':
 			default:
+				header('Content-type:application/json');
 				echo json_encode($data, JSON_UNESCAPED_UNICODE);
 			break;
 		}


### PR DESCRIPTION
Previously, if `settings.json` was not present, no warning was given and a 200 OK was returned.

These changes add a check and make sure a 200 is not accidentally given if output is generated before the section that sets the header is called.

It also makes sure the content-type for JSON is actually set.

@ylebre Would this also fix #1?