### PR TITLE
Fix bug caused by `glob`ing outside the data basedir.

### DIFF
--- a/www/simply-edit/filesystem.php
+++ b/www/simply-edit/filesystem.php
@@ -321,4 +321,9 @@ class filesystem {
 		fclose($lock['resource']);
 		unlink($lock['filename'].'.lock');
 	}
+
+    public static function glob($pattern)
+    {
+        return glob(rtrim(self::$basedir, '/') . '/' . $pattern);
+    }
 }

--- a/www/simply-edit/store.php
+++ b/www/simply-edit/store.php
@@ -30,7 +30,7 @@
 		$user     = $request['user'];
 		$password = $request['password'];
 		if ( $_COOKIE['simply-logout'] 
-			|| (count(htpasswd::$users) && (!$user || !$password || !htpasswd::check($user, $password))) 
+			|| (count(htpasswd::$users) && (!$user || !$password || !htpasswd::check($user, $password)))
 		) {
 			setcookie('simply-logout','',1,'/'); // remove the 'i logged off' cookie
 			header('WWW-Authenticate: Basic realm="Simply Store"');
@@ -43,7 +43,7 @@
 			if ( $request['directory']=='/data/' && $request['filename']=='data.json') {
 				filesystem::copy('/data/','data.json','/data/','data.'.strftime('%Y-%m-%d-%H').'.json');
 				// check number of backups vs max_backups
-				$list = glob('../data/data.*.json');
+				$list = filesystem::glob('/data/data.*.json');
 				if ( count($list) > $settings->max_backups ) {
 					// clean up old backups
 					sort($list);


### PR DESCRIPTION
Previously, when checking if extraneous backup files should be removed, the code did not adhere to the `$baseDir` set on the filesystem.

This MR fixes that, by adding a `glob` function to the filesystem that does take the basedir into account.

It also removes a trailing whitespace.