### PR TITLE
Add GitHub Actions for PHP and JSON linting

### DIFF
--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -1,0 +1,18 @@
+---
+name: Linting jobs
+
+# yamllint disable-line rule:truthy
+on:
+  - push
+  - pull_request
+
+jobs:
+  lint-json:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Lint json
+        uses: "docker://pipelinecomponents/jsonlint:latest"
+        with:
+          args: "find . -not -path './.git/*' -name '*.json' -type f -exec jsonlint --quiet {} ;"
+

--- a/.github/workflows/php-compat.yml
+++ b/.github/workflows/php-compat.yml
@@ -1,0 +1,27 @@
+---
+name: Linting jobs
+
+# yamllint disable-line rule:truthy
+on:
+  - push
+  - pull_request
+
+jobs:
+  php-compat:
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '5.6'
+          - '7.0'
+          - '7.1'
+          - '7.2'
+          - '7.3'
+          - '7.4'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: pipeline-components/php-codesniffer@v0.14.1
+        with:
+          options: "-s --extensions=php --standard=PHPCompatibility --runtime-set testVersion ${{ matrix.version }}"
+

--- a/.github/workflows/php-parallel-lint.yml
+++ b/.github/workflows/php-parallel-lint.yml
@@ -1,0 +1,15 @@
+---
+name: Linting jobs
+
+# yamllint disable-line rule:truthy
+on:
+  - push
+  - pull_request
+
+jobs:
+  php-linter:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: pipeline-components/php-linter@v0.12.6
+

--- a/www/simply-edit/determine_basedir.php
+++ b/www/simply-edit/determine_basedir.php
@@ -26,5 +26,5 @@ function determine_basedir()
         throw new \RuntimeException('Could not reliably determine base directory to store data. ($_SERVER variables "DOCUMENT_ROOT", "PHP_SELF", "SCRIPT_FILENAME", and "SCRIPT_NAME" are all unavailable)');
     }
 
-    return dirname($currentFile, 2);
+    return dirname(dirname($currentFile));
 }

--- a/www/simply-edit/filesystem.php
+++ b/www/simply-edit/filesystem.php
@@ -215,7 +215,7 @@ class filesystem {
 		$finfo      = new finfo(FILEINFO_MIME);
 		$mimetype   = $finfo->file($tempfile);
 		$mimetypes[]= 'inode/x-empty';
-		$mimetypeRe = '{'.implode($mimetypes, '|').'}i';
+		$mimetypeRe = '{'.implode('|', $mimetypes).'}i';
 		if ( !preg_match($mimetypeRe, $mimetype) ) {
 			throw new fsException('Files with mimetype '.$mimetype.' are not allowed in '.$dirname, 108);
 		}

--- a/www/simply-edit/htpasswd.php
+++ b/www/simply-edit/htpasswd.php
@@ -90,7 +90,7 @@
                 $text .= substr($bin, 0, min(16, $i));
             }
             for ($i = $len; $i > 0; $i >>= 1) {
-                $text .= ($i & 1) ? chr(0) : $plainpasswd{0};
+                $text .= ($i & 1) ? chr(0) : $plainpasswd[0];
             }
             $bin = pack("H32", md5($text));
             for ($i = 0; $i < 1000; $i++) {


### PR DESCRIPTION
Because of earlier problems regarding PHP version incompatible code, this MR add linting for the latest PHP version syntax and compatibility with previous versions.

For good measure I've also thrown in a JSON linter, free of charge.

As can be seen [in the checks](https://github.com/SimplyEdit/simply-edit-backend/actions/runs/574738055) there are issues with both 5.6 and 7.4.

This MR also fixes both of these problems.