### PR TITLE
Add PHP 8 to compatibility check.

### DIFF
--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -10,7 +10,7 @@ jobs:
   lint-json:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Lint json
         uses: "docker://pipelinecomponents/jsonlint:latest"
         with:

--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint-json:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Lint json

--- a/.github/workflows/php-compat.yml
+++ b/.github/workflows/php-compat.yml
@@ -1,5 +1,5 @@
 ---
-name: Linting jobs
+name: PHP Compatibility Check
 
 # yamllint disable-line rule:truthy
 on:
@@ -19,9 +19,12 @@ jobs:
           - '7.2'
           - '7.3'
           - '7.4'
+          - '8.0'
+          - '8.1'
+          - '8.2'
     steps:
       - uses: actions/checkout@v2
-      - uses: pipeline-components/php-codesniffer@v0.14.1
+      - uses: pipeline-components/php-codesniffer@v0.28.1
         with:
           options: "-s --extensions=php --standard=PHPCompatibility --runtime-set testVersion ${{ matrix.version }}"
 

--- a/.github/workflows/php-compat.yml
+++ b/.github/workflows/php-compat.yml
@@ -23,7 +23,7 @@ jobs:
           - '8.1'
           - '8.2'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: pipeline-components/php-codesniffer@v0.28.1
         with:
           options: "-s --extensions=php --standard=PHPCompatibility --runtime-set testVersion ${{ matrix.version }}"

--- a/.github/workflows/php-compat.yml
+++ b/.github/workflows/php-compat.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   php-compat:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/php-parallel-lint.yml
+++ b/.github/workflows/php-parallel-lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   php-linter:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: pipeline-components/php-linter@v0.12.6

--- a/.github/workflows/php-parallel-lint.yml
+++ b/.github/workflows/php-parallel-lint.yml
@@ -10,6 +10,6 @@ jobs:
   php-linter:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: pipeline-components/php-linter@v0.12.6
 


### PR DESCRIPTION
This is a first effort in making SimplyEdit-backend compatible with PHP 5.6-8.2