### PR TITLE
Add PHP 8.3 to php-compat.yml check

### DIFF
--- a/.github/workflows/php-compat.yml
+++ b/.github/workflows/php-compat.yml
@@ -23,8 +23,8 @@ jobs:
           - '8.1'
           - '8.2'
     steps:
-      - uses: actions/checkout@v3
-      - uses: pipeline-components/php-codesniffer@v0.28.1
+      - uses: actions/checkout@v4
+      - uses: pipeline-components/php-codesniffer@master
         with:
           options: "-s --extensions=php --standard=PHPCompatibility --runtime-set testVersion ${{ matrix.version }}"
 

--- a/.github/workflows/php-compat.yml
+++ b/.github/workflows/php-compat.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   php-compat:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/php-compat.yml
+++ b/.github/workflows/php-compat.yml
@@ -22,6 +22,7 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.2'
+          - '8.3'
     steps:
       - uses: actions/checkout@v4
       - uses: pipeline-components/php-codesniffer@master


### PR DESCRIPTION
This MR also updates the OS and vendor actions used by the CI check.

The CI/CD failure is caused by PHP version incompatibility. See #14 for resolution.