### PR TITLE
Remove support for PHP < 7.3 from php-compat.yml.

### DIFF
--- a/.github/workflows/php-compat.yml
+++ b/.github/workflows/php-compat.yml
@@ -13,10 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '5.6'
-          - '7.0'
-          - '7.1'
-          - '7.2'
           - '7.3'
           - '7.4'
           - '8.0'


### PR DESCRIPTION
This removes all currently breaking version. More could be removed if desired.